### PR TITLE
Fix nested routers

### DIFF
--- a/packages/trpc-panel/src/react-app/components/contexts/AllPathsContext.tsx
+++ b/packages/trpc-panel/src/react-app/components/contexts/AllPathsContext.tsx
@@ -18,7 +18,7 @@ function flatten(
   if (node.nodeType === "router") {
     const o = Object.values(node.children)
       .map(flatten)
-      .reduce((a, b) => [...a, ...b]);
+      .reduce((a, b) => [...a, ...b], []);
     return [...r, ...o, [node.path.join("."), colorSchemeType]];
   }
 


### PR DESCRIPTION
The panel only shows a blank screen when using nested routers. 
Error message comes from a wrongly used Array.reduce: `TypeError: Reduce of empty array with no initial value`